### PR TITLE
Fixes repo update to also point to zenhack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,20 @@ MAINTAINER Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 
 # Long command to keep the FS deltas small
 RUN apk --update add python \
-		python-dev \
-		py-setuptools \
-		py-pip \
-		openssl-dev \
-		openssl \
-		musl-dev \
-		gcc \
-		libffi-dev \
-		darkhttpd \
-	&& wget -qO- https://codeload.github.com/zenhack/simp_le/tar.gz/master | tar xz \
-	&& pip install -e /simp_le-master/ \
-	&& mkdir /certs \
-	&& apk --purge del musl-dev openssl-dev libffi-dev gcc python-dev py-pip
+        python-dev \
+        py-setuptools \
+        py-pip \
+        openssl-dev \
+        openssl \
+        musl-dev \
+        gcc \
+        libffi-dev \
+        git \
+        darkhttpd \
+    && git clone https://github.com/zenhack/simp_le.git /simp_le-master \
+    && pip install -e /simp_le-master/ \
+    && mkdir /certs \
+    && apk --purge del musl-dev openssl-dev libffi-dev gcc python-dev py-pip
 WORKDIR /certs
 COPY ["./startme.sh", "/usr/local/bin/"]
 ENTRYPOINT ["/usr/local/bin/startme.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apk --update add python \
         libffi-dev \
         git \
         darkhttpd \
-    && git clone https://github.com/zenhack/simp_le.git /simp_le-master \
-    && pip install -e /simp_le-master/ \
+    && git clone --single-branch --branch 0.15.0 https://github.com/zenhack/simp_le.git /simp_le \
+    && pip install -e /simp_le/ \
     && mkdir /certs \
     && apk --purge del musl-dev openssl-dev libffi-dev gcc python-dev py-pip
 WORKDIR /certs

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Certs are saved in `/certs` so you should mount a persistent volume there.
 If you only want to get some certificates, simply run the container like this:
 
 	docker run -ti -p 80:80 -v /etc/nginx/certs:/certs \
-	dokku/letsencrypt-simp_le -f account_key.json -f account_reg.json  \
+	dokku/letsencrypt -f account_key.json -f account_reg.json  \
 	-f chain.pem -f cert.pem -f key.pem --email a@example.org \
     -d adminswerk.de -d test.adminswerk.de
 
@@ -19,4 +19,4 @@ If you only want to get some certificates, simply run the container like this:
 By default the container starts with an entrypoint-script which passes all arguments you start the container with to `simp_le.py`. If you want to start another application, e.g. for debugging or to build something ontop the container, you have to set the environment variable `OVERRIDE`. Identical to `SKIP_REFRESH`, it only needs to be not null, the value doesn't matter. `OVERRIDE` implies `SKIP_REFRESH` (but not the other way around), so no need to define both envs.
 
 	docker run -ti -p 80:80 -v /etc/nginx/certs:/certs -e "OVERRIDE=1" \
-		dokku/letsencrypt-simp_le sh
+		dokku/letsencrypt sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # docker-letsencrypt
 
-This is a containerfile for the **"simp_le"** Let's encrypt implementation by kuba (https://github.com/kuba/simp_le). It's running on Alpine Linux and is only around 60MB in size.
-It was inspired by `katta/sim_le` but has a couple of improvements.
+This is a containerfile for the **"simp_le"** Let's encrypt implementation by zenhack (https://github.com/zenhack/simp_le). It's running on Alpine Linux and is only around 60MB in size.
+It was inspired by `kuba/simp_le` and `katta/sim_le` but has a couple of improvements.
 
 Certs are saved in `/certs` so you should mount a persistent volume there.
 
@@ -10,17 +10,9 @@ Certs are saved in `/certs` so you should mount a persistent volume there.
 If you only want to get some certificates, simply run the container like this:
 
 	docker run -ti -p 80:80 -v /etc/nginx/certs:/certs \
-	dokku/letsencrypt-simp_le -f account_key.json  \
+	dokku/letsencrypt-simp_le -f account_key.json -f account_reg.json  \
 	-f chain.pem -f cert.pem -f key.pem --email a@example.org \
     -d adminswerk.de -d test.adminswerk.de
-
-#### Repo Refresh
-
-**simp_le** is refreshed from the repos master branch at container start. This normally takes not more than one second and ensures it's always up to date. If you want to disable this functionality, start the container with the environment variable `SKIP_REFRESH` set. It doesn't matter which value it contains as long as it's not null.
-
-	docker run -ti -p 80:80 -v /etc/nginx/certs:/certs -e "SKIP_REFRESH=1" \
-		dokku/letsencrypt-simp_le -f account_key.json  -f chain.pem \
-		-f cert.pem -f key.pem --email a@example.org -d adminswerk.de
 
 #### Entrypoint Override
 

--- a/startme.sh
+++ b/startme.sh
@@ -10,7 +10,7 @@ then
 	darkhttpd /var/www/html --port 80 --daemon
 	if [ -z "${SKIP_REFRESH}" ]
 	then
-		wget -qO- https://codeload.github.com/dokku/simp_le/tar.gz/master | tar xz -C /
+		wget -qO- https://codeload.github.com/zenhack/simp_le/tar.gz/master | tar xz -C /
 	fi
 	/simp_le-master/simp_le.py --default_root /var/www/html "$@"
 else

--- a/startme.sh
+++ b/startme.sh
@@ -13,6 +13,7 @@ then
         cd /simp_le-master
         git pull
     fi
+    cd /certs
     /simp_le-master/simp_le.py --default_root /var/www/html "$@"
 else
     "$@"

--- a/startme.sh
+++ b/startme.sh
@@ -6,13 +6,14 @@ SKIP_REFRESH=${SKIP_REFRESH:-}
 
 if [ -z "${OVERRIDE}" ]
 then
-	mkdir -p /var/www/html
-	darkhttpd /var/www/html --port 80 --daemon
-	if [ -z "${SKIP_REFRESH}" ]
-	then
-		wget -qO- https://codeload.github.com/zenhack/simp_le/tar.gz/master | tar xz -C /
-	fi
-	/simp_le-master/simp_le.py --default_root /var/www/html "$@"
+    mkdir -p /var/www/html
+    darkhttpd /var/www/html --port 80 --daemon
+    if [ -z "${SKIP_REFRESH}" ]
+    then
+        cd /simp_le-master
+        git pull
+    fi
+    /simp_le-master/simp_le.py --default_root /var/www/html "$@"
 else
-	"$@"
+    "$@"
 fi

--- a/startme.sh
+++ b/startme.sh
@@ -2,19 +2,12 @@
 set -e
 
 OVERRIDE=${OVERRIDE:-}
-SKIP_REFRESH=${SKIP_REFRESH:-}
 
 if [ -z "${OVERRIDE}" ]
 then
     mkdir -p /var/www/html
     darkhttpd /var/www/html --port 80 --daemon
-    if [ -z "${SKIP_REFRESH}" ]
-    then
-        cd /simp_le-master
-        git pull
-    fi
-    cd /certs
-    /simp_le-master/simp_le.py --default_root /var/www/html "$@"
+    /simp_le/simp_le.py --default_root /var/www/html "$@"
 else
     "$@"
 fi


### PR DESCRIPTION
The `startme` script pointed to a different repo than the `Dockerfile`. Because of this, ACMEv2 support was removed on each run unless refresh was disabled.

This resolves that issue.